### PR TITLE
Mikrotik RouterOS 6.13+ support comments anywhere that a '/' is supported

### DIFF
--- a/MikrotikScript.YAML-tmLanguage
+++ b/MikrotikScript.YAML-tmLanguage
@@ -43,14 +43,10 @@ repository:
   comments:
     patterns:
     - name: comment.line.number-sign.mikrotik-script
-      match: ^(#).*$\n?
+      match: (#).*$\n?
       captures:
         '1': {name: punctuation.definition.comment.mikrotik-script}
       comment: comments are ignored by syntax
-
-    - match: (#.*)$\n?
-      captures:
-        '1': {name: invalid.illegal.unexpected-comment.mikrotik-script}
 
   parameters-readwrite:
     patterns:

--- a/MikrotikScript.tmLanguage
+++ b/MikrotikScript.tmLanguage
@@ -106,21 +106,9 @@
 					<key>comment</key>
 					<string>comments are ignored by syntax</string>
 					<key>match</key>
-					<string>^(#).*$\n?</string>
+					<string>(#).*$\n?</string>
 					<key>name</key>
 					<string>comment.line.number-sign.mikrotik-script</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>invalid.illegal.unexpected-comment.mikrotik-script</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(#.*)$\n?</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
I'm new to Sublime Text / TextMate formatting packages, but this change "works for me". Comments are now allowed anywhere in a line -- this was done by removing the "invalid comment" pattern. Note that there is probably some additional work to validate that comments are valid only where they are valid in the actual script file, but I think this might be an issue for other tokens (ie: slashes) as well.
