### PR TITLE
Add new parameter to list

### DIFF
--- a/readwrite-parameters.sublime-completions
+++ b/readwrite-parameters.sublime-completions
@@ -243,6 +243,7 @@
 		"default-client-tx-limit=",
 		"default-cost=",
 		"default-forwarding=",
+		"default-for-dynamic="
 		"default-group=",
 		"default-name=",
 		"default-originate=",


### PR DESCRIPTION
Add default-for-dynamic parameter used in "/ip neighbor discovery settings"
for setting the default state of dynamic interfaces.